### PR TITLE
Release for v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.2.3](https://github.com/yumafuu/s1m/compare/v0.2.2...v0.2.3) - 2024-08-06
+- [chore] dependabot by @yumafuu in https://github.com/yumafuu/s1m/pull/9
+- Bump github.com/aws/aws-sdk-go-v2/config from 1.27.18 to 1.27.27 by @dependabot in https://github.com/yumafuu/s1m/pull/10
+- Bump github.com/gdamore/tcell/v2 from 2.7.1 to 2.7.4 by @dependabot in https://github.com/yumafuu/s1m/pull/12
+- [fix] panic by @yumafuu in https://github.com/yumafuu/s1m/pull/14
+- [add] ptree test by @yumafuu in https://github.com/yumafuu/s1m/pull/15
+- Bug: new param on dir by @yumafuu in https://github.com/yumafuu/s1m/pull/16
+
 ## [v0.2.2](https://github.com/yumafuu/s1m/compare/v0.2.1...v0.2.2) - 2024-07-29
 - [add] tagpr by @yumafuu in https://github.com/yumafuu/s1m/pull/5
 - [Chore] Update tagpr token by @yumafuu in https://github.com/yumafuu/s1m/pull/6


### PR DESCRIPTION
This pull request is for the next release as v0.2.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [chore] dependabot by @yumafuu in https://github.com/yumafuu/s1m/pull/9
* Bump github.com/aws/aws-sdk-go-v2/config from 1.27.18 to 1.27.27 by @dependabot in https://github.com/yumafuu/s1m/pull/10
* Bump github.com/gdamore/tcell/v2 from 2.7.1 to 2.7.4 by @dependabot in https://github.com/yumafuu/s1m/pull/12
* [fix] panic by @yumafuu in https://github.com/yumafuu/s1m/pull/14
* [add] ptree test by @yumafuu in https://github.com/yumafuu/s1m/pull/15
* Bug: new param on dir by @yumafuu in https://github.com/yumafuu/s1m/pull/16

## New Contributors
* @dependabot made their first contribution in https://github.com/yumafuu/s1m/pull/10

**Full Changelog**: https://github.com/yumafuu/s1m/compare/v0.2.2...v0.2.3